### PR TITLE
fix: .eslintcache를 .gitignore에 넣기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# eslint
+.gitignore
+
 # testing
 /coverage
 


### PR DESCRIPTION
.eslintcache는 다른사람이 알 필요가 업으니 .gitignore에 추가

Resolves: fix/#5