### PR TITLE
fix: eslintrc를 gitignore에 넣기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .pnp.js
 
 # eslint
-.gitignore
+.eslintrc
 
 # testing
 /coverage


### PR DESCRIPTION
이슈 #5에서 eslintrc를 gitignore에 넣은 줄 알았는데 gitignore을 넣음 eslintrc를 gitignore에 넣는걸로 수정

Resolves: #13